### PR TITLE
Fix /download internal server error

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,2 @@
+VUE_APP_ROOT_API=http://localhost:3000
+VUE_APP_HOST_ADDRESS=http://localhost:8080

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,3 @@
+NODE_ENV=production
+VUE_APP_ROOT_API=https://api.sustainability.oregonstate.edu/v2/carbon-calculator
+VUE_APP_HOST_ADDRESS=https://myco2.sustainability.oregonstate.edu

--- a/backend/app/carbon/app.js
+++ b/backend/app/carbon/app.js
@@ -40,9 +40,9 @@ exports.questions = async (event, context) => {
 exports.download = async (event, context) => {
   // Create empty response object from model
   let response = new Response()
-
   // Create user object with current user's context (this gets user data from a JSON Web Token)
   let u = new User(event, response)
+  await u.resolve
 
   // Retrieve that user's data from the db
   DDB.initialize()
@@ -58,7 +58,7 @@ exports.download = async (event, context) => {
 
   // Return user data
   response.body = JSON.stringify({
-    data: data.Items[0].data,
+    data: (data.Items[0]) ?  data.Items[0].data : [],
     onid: u.onid,
     firstName: u.firstName,
     primaryAffiliation: u.primaryAffiliation,

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -15,7 +15,7 @@ Globals:
 Parameters:
   LambdaCommonLayer:
     Type: String
-    Default: arn:aws:lambda:us-west-2:005937143026:layer:LambdaCommonLayer:67
+    Default: arn:aws:lambda:us-west-2:005937143026:layer:LambdaCommonLayer:97
 
 Resources:
   ccUserDataDownload:
@@ -25,7 +25,7 @@ Resources:
         - AmazonDynamoDBFullAccess
       CodeUri: app/carbon
       Handler: app.download
-      Runtime: nodejs10.x
+      Runtime: nodejs12.x
       Layers:
         - !Ref LambdaCommonLayer
       Events:
@@ -41,7 +41,7 @@ Resources:
         - AmazonDynamoDBFullAccess
       CodeUri: app/carbon
       Handler: app.upload
-      Runtime: nodejs10.x
+      Runtime: nodejs12.x
       Layers:
         - !Ref LambdaCommonLayer
       Events:
@@ -57,7 +57,7 @@ Resources:
         - AmazonDynamoDBFullAccess
       CodeUri: app/carbon
       Handler: app.delete
-      Runtime: nodejs10.x
+      Runtime: nodejs12.x
       Layers:
         - !Ref LambdaCommonLayer
       Events:
@@ -73,7 +73,7 @@ Resources:
         - AmazonDynamoDBFullAccess
       CodeUri: app/carbon
       Handler: app.questions
-      Runtime: nodejs10.x
+      Runtime: nodejs12.x
       Layers:
         - !Ref LambdaCommonLayer
       Events:

--- a/src/main.js
+++ b/src/main.js
@@ -24,12 +24,13 @@ Vue.use(Vuei18n)
 Vue.use(elm, { locale: locale })
 
 Vue.config.productionTip = false
-
+Vue.config.debug = false
+Vue.config.devtools = false
 // Configure axios with sustainability api base url
-axios.defaults.baseURL = 'https://api.sustainability.oregonstate.edu/v2/carbon-calculator'
+axios.defaults.baseURL = process.env.VUE_APP_ROOT_API
 
 /* eslint-disable no-new */
-new Vue({
+window.vue = new Vue({
   el: '#app',
   router,
   store,


### PR DESCRIPTION
Should address the internal server error occurring for #35 when the calculator attempts to load a user's carbon usage history.

Solved by:
1. Making sure User object loads correctly by awaiting the `resolve` promise property.
2. If the user has no history, not attempting to return an the non-existent Items array (`data.Items[0]` is undefined for new users which triggers the internal server error): `data: (data.Items[0]) ?  data.Items[0].data : [],`

Testing this locally is a challenge since the cookies from the Auth routes weren't getting sent to the `localhost:3000` API so the auth cookie-check would always fail.

Therefore, I tested this API route change by:
Copying the `/download` route request as a CURL object (to get a request w/ valid JWT cookie in the header):

<img width="1440" alt="Screen Shot 2022-12-30 at 2 40 16 PM" src="https://user-images.githubusercontent.com/26470611/210116137-1a483e19-83f4-455b-bbad-2e3744930cf5.png">

Then in my terminal replacing the API route with the localhost API instance running on my machine via `sam local start-api`:

<img width="1003" alt="Screen Shot 2022-12-30 at 2 41 48 PM" src="https://user-images.githubusercontent.com/26470611/210116284-91a23c9b-3329-4de6-8f7e-c8c053ce5876.png">

Which appears to have returned valid data from the DynamoDB